### PR TITLE
Add key management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,47 @@
 User
 =========
 
-This roles creates the user `user` on a Debian (based) system. Used for the [provision](https://github.com/oneofftech/provision) setup. The account has direct super user access (through sudo) and it optionally gets password information from a simple, encryped [KeePass databse](https://keepass.info/).
+This roles creates the user `user` on a Debian (based) system. Used for the [provision](https://github.com/oneofftech/provision) setup. The account has direct super user access (through sudo) and it optionally gets password information from a simple, encryped [KeePass database](https://keepass.info/).
 
 This is work in progress and it is prefered to collaborate on it. Please communicate over the issue queue. Every pull request is highly appreciated.
+
+Requirements
+------------
+
+None
+
+
+Role Variables
+--------------
+
+```yaml
+system_user: ""          # populated from keepass
+system_user_password: "" # populated from keepass
+
+system_user_authorized_keys: []
+```
+
+Dependencies
+------------
+
+None
+
+Example Variables
+-----------------
+
+```yaml
+system_user_authorized_keys:
+  - ssh-ed25519 AAAAC3XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX me@desktop
+```
 
 Example Playbook
 ----------------
 
-    - hosts: servers
-      roles:
-         - { role: xamanu.essentials }
+```yaml
+- hosts: servers
+  roles:
+     - { role: xamanu.essentials }
+```
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,5 @@
 ---
 # defaults file for ansible-role-user
+
+# array of SSH keys authorized to access the host.
+system_user_authorized_keys: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,15 @@
       generate_ssh_key: yes # generate default id_rsa
       password: "{{ system_user_password|password_hash('sha512') }}"
       groups: "ssh_login,sudo,docker"
+      shell: "/bin/bash"
       update_password: on_create
+
+  - name: install trusted public keys
+    authorized_key:
+       user: "{{ system_user_username }}"
+       state: present
+       key: "{{ item }}"
+    with_items: "{{ system_user_authorized_keys }}"
 
   - name: ensure user can use sudo without password
     lineinfile:


### PR DESCRIPTION
This MR adds key management. It introduces a new variable, `system_user_authorized_key`. The default variable is empty, but it should be populated with trusted SSH keys from `group_vars` or `host_vars`.